### PR TITLE
Add tag write support and read ranges

### DIFF
--- a/NFCReader.py
+++ b/NFCReader.py
@@ -108,7 +108,7 @@ if __name__ == "__main__":
 			if "-" in page:
 				start = int(page.split("-")[0])
 				end = int(page.split("-")[1])
-				for new_page in xrange(start, end):
+				for new_page in xrange(start, end+1):
 					readTag(new_page)
 			else:
 				readTag(page)

--- a/NFCReader.py
+++ b/NFCReader.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-import re
+import re, argparse
 from smartcard.System import readers
 import datetime
 
@@ -16,36 +16,99 @@ print "Available readers:", r
 reader = r[0]
 print "Using:", reader
 
-#data from NFC tag
-data = ''
+def stringParser(dataCurr):
+#--------------String Parser--------------#
+	#([85, 203, 230, 191], 144, 0) -> [85, 203, 230, 191]
+	if isinstance(dataCurr, tuple):
+		temp = dataCurr[0]
+		code = dataCurr[1]
+	#[85, 203, 230, 191] -> [85, 203, 230, 191]
+	else:
+		temp = dataCurr
+		code = 0
 
-while(1):
-	try:
-		connection = reader.createConnection()
-		status_connection = connection.connect()
-		dataCurr = connection.transmit(COMMAND)
+	dataCurr = ''
 
-		#--------------String Parser--------------#
-		#([85, 203, 230, 191], 144, 0) -> [85, 203, 230, 191]
-		if isinstance(dataCurr, tuple):
-			temp = dataCurr[0]
-		#[85, 203, 230, 191] -> [85, 203, 230, 191]
+	#[85, 203, 230, 191] -> bfe6cb55 (int to hex reversed)
+	for val in temp:
+		# dataCurr += (hex(int(val))).lstrip('0x') # += bf
+		dataCurr += format(val, '#04x')[2:] # += bf
+
+	#bfe6cb55 -> BFE6CB55
+	dataCurr = dataCurr.upper()
+
+	#if return is successful
+	if (code == 144):
+		return dataCurr
+
+def readTag(page):
+	while(1):
+		try:
+			connection = reader.createConnection()
+			status_connection = connection.connect()
+			connection.transmit(COMMAND)
+			#Read command [FF, B0, 00, page, #bytes]
+			resp = connection.transmit([0xFF, 0xB0, 0x00, int(page), 0x04])
+			dataCurr = stringParser(resp)
+
+			#only allows new tags to be worked so no duplicates
+			if(dataCurr is not None):
+				print dataCurr
+				break
+			else:
+				print "Something went wrong. Page " + str(page)
+				break
+		except Exception, e:
+			continue
+
+def writeTag(page, value):
+	if type(value) != str:
+		print "Value input should be a string"
+		exit()
+	while(1):
+		if len(value) == 8:
+			try:
+				connection = reader.createConnection()
+				status_connection = connection.connect()
+				connection.transmit(COMMAND)
+				WRITE_COMMAND = [0xFF, 0xD6, 0x00, int(page), 0x04, int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16), int(value[6:8], 16)]
+				# Let's write a page Page 9 is usually 00000000
+				resp = connection.transmit(WRITE_COMMAND)
+				if resp[1] == 144:
+					print "Wrote " + value + " to page " + str(page)
+					break
+			except Exception, e:
+				continue
 		else:
-			temp = dataCurr
+			print "Must have a full 4 byte write value"
+			break
 
-		dataCurr = ''
+if __name__ == "__main__":
+	parser = argparse.ArgumentParser(description='Read / write NFC tags')
+	read_group = parser.add_argument_group('read')
+	read_group.add_argument('--read', nargs='+', help='Pages to read. Can be a x-x range, or list of pages')
+	write_group = parser.add_argument_group('write')
+	write_group.add_argument('--write', nargs=2, metavar=('PAGE', 'DATA'), help='Page number and hex value to write.')
 
-		#[85, 203, 230, 191] -> bfe6cb55 (int to hex reversed)
-		for val in temp:
-			# dataCurr += (hex(int(val))).lstrip('0x') # += bf
-			dataCurr += format(val, '#04x')[2:] # += bf
 
-		#bfe6cb55 -> BFE6CB55
-		dataCurr = dataCurr.upper()
+	args = parser.parse_args()
 
-		#only allows new tags to be worked so no duplicates
-		if(dataCurr != data):
-			data = dataCurr
-
-	except Exception, e:
-		continue
+	#Only going to write one page at a time
+	if args.write:
+		page = args.write[0]
+		data = args.write[1]
+		if len(data) == 8:
+			writeTag(int(page), data)
+		else:
+			raise argparse.ArgumentTypeError("Must have a full 4 byte write value")
+	
+	#Page numbers are sent as ints, not hex, to the reader
+	if args.read:
+		for page in args.read:
+			if "-" in page:
+				start = int(page.split("-")[0])
+				end = int(page.split("-")[1])
+				for new_page in xrange(start, end):
+					readTag(new_page)
+			else:
+				readTag(page)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-ACS ACR122U NFC Reader
+ACS ACR122U NFC Reader / Writer
 =========
 
-Python based reader that is used to read tag data from the NFC ISO 14443 Type A and B cards, Mifare, FeliCa, and all 4 types of NFC (ISO/IEC 18092) tags.
+Python based reader/writer that is used to read tag data from the NFC ISO 14443 Type A and B cards, Mifare, FeliCa, and all 4 types of NFC (ISO/IEC 18092) tags.
 
 Code provides a basic framework used to grab tag data.
 


### PR DESCRIPTION
Expect amateur code, but it all seems to be working standalone and as a module. Tested on OSX Yosemite 10.10.

Added:
-Range support when using as a standalone file. Ex: "--read 10-15" or "--read 10 11 12 13 14 15" will work.
-Single page write support. I'm using UID rewriteable tags, so I'm not checking for data-only pages.
